### PR TITLE
Removing cpu option for now due to errors when uploading files

### DIFF
--- a/form.yml.erb
+++ b/form.yml.erb
@@ -41,10 +41,6 @@ attributes:
      <small>
      <ul>
       <li>
-        <b>CPU/GPU</b>: Option to run on GPU for significantly faster response times, 
-        though GPU resources may be subject to availability constraints
-      </li>
-      <li>
         <b>Thinking</b>: Excels at solving complex problems by systematically evaluating 
         multiple possibilities to deliver reasoned answers
       </li>
@@ -75,16 +71,3 @@ attributes:
         data-set-ec-mem:  "12",
         data-set-ec-gpus:  "1",
       ]
-    - [
-        "[CPU] Thinking (GPT-OSS 20B)", "gpt-oss_20b_cpu",
-        data-set-ec-cpus:  "12",
-        data-set-ec-mem:  "24",
-        data-set-ec-gpus:  "0",
-      ]
-    - [
-        "[CPU] Medical Images, Vision (Medgemma 4B)", "medgemma_4b_cpu",
-        data-set-ec-cpus:  "12",
-        data-set-ec-mem:  "12",
-        data-set-ec-gpus:  "0",
-      ]
-


### PR DESCRIPTION
For the cpu option, users may experience an error message (JSON.parse: unexpected character at line 1 column 1 of the JSON data) when attempting to upload anything but very small files. 

This is due to the need for timeout adjustement, which is being worked on, but is not ready for now.